### PR TITLE
Nevermind captcha if it's hidden

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -14,7 +14,8 @@ class Parser {
     }
 
     get isLocked() {
-        return this.$('.g-recaptcha').index() > 0;
+        return this.$('.g-recaptcha').index()
+            && this.$('.g-recaptcha').attr('style') !== 'display: none';
     }
 
     get tickets() {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -14,7 +14,7 @@ class Parser {
     }
 
     get isLocked() {
-        return this.$('.g-recaptcha').index()
+        return this.$('.g-recaptcha').index() >= 0
             && this.$('.g-recaptcha').attr('style') !== 'display: none';
     }
 


### PR DESCRIPTION
Looks like TicketSwap has figured out how this script works and started always showing a hidden captcha:
```html
<div class="g-recaptcha" style="display: none">🖕</div>
```

Which caused the parser to show the "Locked by TicketSwap from performing more requests" error and give up. I added another condition to see if captcha is hidden.