### PR TITLE
Use the 'open' package instead of child_process

### DIFF
--- a/lib/found-ticket.js
+++ b/lib/found-ticket.js
@@ -2,7 +2,7 @@
 
 const chalk = require('chalk');
 const request = require('./request').request;
-const exec = require('child_process').exec;
+const open = require('open');
 const cheerio = require('cheerio');
 const logger = require('./logger');
 const utils = require('./utils');
@@ -95,7 +95,7 @@ function runFound(link, options) {
                 sound: true,
             });
 
-            exec('open -a "Google Chrome" https://www.ticketswap.nl/cart');
+            open('https://www.ticketswap.nl/cart');
 
             return {
                 alreadySold: false,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "debug": "~2.2.0",
     "growl": "~1.9.2",
     "node-notifier": "~4.6.1",
+    "open": "0.0.5",
     "random-useragent": "^0.3.1",
     "request": "~2.75.0",
     "yargs": "~8.0.1"


### PR DESCRIPTION
Node notifier works great on windows but the exec command opening the cart does not. I think the open package that I used is cross platform. Let me know what you think!

Cheers!

Arjen